### PR TITLE
Make vanilla weapons compatible with CBA magazine wells

### DIFF
--- a/addons/gsri_vanilla_compat/config.cpp
+++ b/addons/gsri_vanilla_compat/config.cpp
@@ -23,9 +23,20 @@ class CfgMagazineWells {
     };
 };
 
+class asdg_OpticRail1913;
+
 class CfgWeapons {
-    class Rifle_Base_F;
+    class Rifle;
+    class Rifle_Base_F : Rifle {
+        class WeaponSlotsInfo;
+    };
     class arifle_MSBS65_base_F : Rifle_Base_F {
         magazineWell[] += {"CBA_556x45_STANAG"};
+        class WeaponSlotsInfo: WeaponSlotsInfo {
+            class CowsSlot: asdg_OpticRail1913 {
+                iconPosition[] = {0.45,0.28};
+                iconScale = 0.2;
+            };
+        };
     };
 };

--- a/addons/gsri_vanilla_compat/config.cpp
+++ b/addons/gsri_vanilla_compat/config.cpp
@@ -1,0 +1,24 @@
+class CfgPatches {
+    class gsri_vanilla_compat {
+        units[]={};
+        requiredVersion=0.1;
+        requiredAddons[]={"cba_jr", "cba_jam"};
+        author="[-GSRI-] Cheitan";
+    };
+};
+
+class CfgMagazineWells {
+    class CBA_556x45_STANAG {
+        SMA_mags[] = {
+            "SMA_30Rnd_556x45_M855A1",
+            "SMA_30Rnd_556x45_M855A1_Tracer",
+            "SMA_30Rnd_556x45_M855A1_IR",
+            "SMA_30Rnd_556x45_Mk318",
+            "SMA_30Rnd_556x45_Mk318_Tracer",
+            "SMA_30Rnd_556x45_Mk318_IR",
+            "SMA_30Rnd_556x45_Mk262",
+            "SMA_30Rnd_556x45_Mk262_Tracer",
+            "SMA_30Rnd_556x45_Mk262_IR"
+        };
+    };
+};

--- a/addons/gsri_vanilla_compat/config.cpp
+++ b/addons/gsri_vanilla_compat/config.cpp
@@ -22,3 +22,10 @@ class CfgMagazineWells {
         };
     };
 };
+
+class CfgWeapons {
+    class Rifle_Base_F;
+    class arifle_MSBS65_base_F : Rifle_Base_F {
+        magazineWell[] += {"CBA_556x45_STANAG"};
+    };
+};

--- a/addons/gsri_vanilla_compat/config.cpp
+++ b/addons/gsri_vanilla_compat/config.cpp
@@ -24,6 +24,7 @@ class CfgMagazineWells {
 };
 
 class asdg_OpticRail1913;
+class asdg_FrontSideRail;
 
 class CfgWeapons {
     class Rifle;
@@ -35,6 +36,10 @@ class CfgWeapons {
         class WeaponSlotsInfo: WeaponSlotsInfo {
             class CowsSlot: asdg_OpticRail1913 {
                 iconPosition[] = {0.45,0.28};
+                iconScale = 0.2;
+            };
+            class PointerSlot: asdg_FrontSideRail {
+                iconPosition[] = {0.35,0.45};
                 iconScale = 0.2;
             };
         };


### PR DESCRIPTION
Basically, add custom magazines compatibility for the vanilla HK416 and MSBS series. The first one is actually a native 556 rifle, the second one is a fictionnal rifle originally chambered in 6.5.

MSBS also receive compatibility for modded optics and siderail attachments.