### PR TITLE
Fix: hearing protection

### DIFF
--- a/addons/gsri_equipment/headgear/headgear.hpp
+++ b/addons/gsri_equipment/headgear/headgear.hpp
@@ -32,6 +32,8 @@ class GSRI_helmet : H_HelmetB {
     hiddenSelections[] = { "camo" };
     hiddenSelectionsTextures[] = { "\fr\gsri\equipment\headgear\Data\helmet_co.paa"};
     hiddenSelectionsMaterials[] = {"\fr\gsri\equipment\headgear\Data\helmet.rvmat"};
+    ace_hearing_protection = 0;
+    ace_hearing_lowerVolume = 0;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F\BLUFOR\headgear_b_helmet_plain.p3d";
@@ -56,6 +58,8 @@ class GSRI_helmet_spec : H_HelmetSpecB {
     hiddenSelections[] = { "camo" };
     hiddenSelectionsTextures[] = { "\fr\gsri\equipment\headgear\Data\helmet_co.paa"};
     hiddenSelectionsMaterials[] = {"\fr\gsri\equipment\headgear\Data\helmet.rvmat"};
+    ace_hearing_protection = 0.5;
+    ace_hearing_lowerVolume = 0.3;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F\BLUFOR\headgear_b_helmet_ballistic.p3d";
@@ -80,6 +84,8 @@ class GSRI_helmet_light : H_HelmetB_light {
     hiddenSelections[] = { "camo" };
     hiddenSelectionsTextures[] = { "\fr\gsri\equipment\headgear\Data\helmet_co.paa"};
     hiddenSelectionsMaterials[] = {"\fr\gsri\equipment\headgear\Data\helmet.rvmat"};
+    ace_hearing_protection = 0.5;
+    ace_hearing_lowerVolume = 0.3;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F\BLUFOR\headgear_b_helmet_light.p3d";
@@ -103,6 +109,8 @@ class GSRI_helmet_modular : H_HelmetB {
     model = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_F.p3d";
     hiddenSelections[] = { "camo" };
     hiddenSelectionsTextures[] = { "\fr\gsri\equipment\headgear\Data\helmet_modular_co.paa"};
+    ace_hearing_protection = 0;
+    ace_hearing_lowerVolume = 0;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_F.p3d";
@@ -123,6 +131,8 @@ class GSRI_helmet_modular_advanced : GSRI_helmet_modular {
     displayName = "$STR_GSRI_HEADGEAR_HELMET_MODULAR_ACCESSORIES";
     picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet_modular_accessories.paa";
     model = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_headset_F.p3d";
+    ace_hearing_protection = 0.5;
+    ace_hearing_lowerVolume = 0.3;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_headset_F.p3d";
@@ -143,6 +153,8 @@ class GSRI_helmet_modular_integral : GSRI_helmet_modular {
     displayName = "$STR_GSRI_HEADGEAR_HELMET_MODULAR_INTEGRAL";
     picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet_modular_accessories.paa";
     model = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_chops_F.p3d";
+    ace_hearing_protection = 0.5;
+    ace_hearing_lowerVolume = 0.3;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_chops_F.p3d";

--- a/addons/gsri_equipment/headgear/headgear.hpp
+++ b/addons/gsri_equipment/headgear/headgear.hpp
@@ -33,8 +33,6 @@ class GSRI_helmet : H_HelmetB {
     hiddenSelections[] = { "camo" };
     hiddenSelectionsTextures[] = { "\fr\gsri\equipment\headgear\Data\helmet_co.paa"};
     hiddenSelectionsMaterials[] = {"\fr\gsri\equipment\headgear\Data\helmet.rvmat"};
-    ace_hearing_protection = 0;
-    ace_hearing_lowerVolume = 0;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F\BLUFOR\headgear_b_helmet_plain.p3d";
@@ -60,8 +58,6 @@ class GSRI_helmet_spec : H_HelmetSpecB {
     hiddenSelections[] = { "camo" };
     hiddenSelectionsTextures[] = { "\fr\gsri\equipment\headgear\Data\helmet_co.paa"};
     hiddenSelectionsMaterials[] = {"\fr\gsri\equipment\headgear\Data\helmet.rvmat"};
-    ace_hearing_protection = 0.5;
-    ace_hearing_lowerVolume = 0.3;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F\BLUFOR\headgear_b_helmet_ballistic.p3d";
@@ -87,8 +83,6 @@ class GSRI_helmet_light : H_HelmetB_light {
     hiddenSelections[] = { "camo" };
     hiddenSelectionsTextures[] = { "\fr\gsri\equipment\headgear\Data\helmet_co.paa"};
     hiddenSelectionsMaterials[] = {"\fr\gsri\equipment\headgear\Data\helmet.rvmat"};
-    ace_hearing_protection = 0.5;
-    ace_hearing_lowerVolume = 0.3;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F\BLUFOR\headgear_b_helmet_light.p3d";
@@ -113,8 +107,6 @@ class GSRI_helmet_modular : H_HelmetB {
     model = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_F.p3d";
     hiddenSelections[] = { "camo" };
     hiddenSelectionsTextures[] = { "\fr\gsri\equipment\headgear\Data\helmet_modular_co.paa"};
-    ace_hearing_protection = 0;
-    ace_hearing_lowerVolume = 0;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_F.p3d";
@@ -130,14 +122,14 @@ class GSRI_helmet_modular : H_HelmetB {
     };
 };
 
-class GSRI_helmet_modular_advanced : GSRI_helmet_modular {
+class GSRI_helmet_modular_advanced : H_HelmetSpecB {
     author = "$STR_GSRI_AUTHORS_PHILEAS";
     displayName = "$STR_GSRI_HEADGEAR_HELMET_MODULAR_ACCESSORIES";
     descriptionShort="$STR_A3_SP_AL_II";
     picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet_modular_accessories.paa";
     model = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_headset_F.p3d";
-    ace_hearing_protection = 0.5;
-    ace_hearing_lowerVolume = 0.3;
+    hiddenSelections[] = { "camo" };
+    hiddenSelectionsTextures[] = { "\fr\gsri\equipment\headgear\Data\helmet_modular_co.paa"};
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_headset_F.p3d";
@@ -153,14 +145,33 @@ class GSRI_helmet_modular_advanced : GSRI_helmet_modular {
     };
 };
 
-class GSRI_helmet_modular_integral : GSRI_helmet_modular {
+class GSRI_helmet_modular_halfintegral : GSRI_helmet_modular_advanced {
+    author = "$STR_GSRI_AUTHORS_PHILEAS";
+    displayName = "$STR_GSRI_HEADGEAR_HELMET_MODULAR_HALFINTEGRAL";
+    descriptionShort="$STR_A3_SP_AL_II";
+    picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet_modular_accessories.paa";
+    model = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_ear_F.p3d";
+    class ItemInfo : HeadgearItem {
+        mass = 30;
+        uniformModel = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_ear_F.p3d";
+        modelSides[] = { TCivilian, TWest };
+        hiddenSelections[] = { "camo" };
+        class HitpointsProtectionInfo {
+            class Head {
+                hitPointName = "HitHead";
+                armor = 6;
+                passThrough = 0.5;
+            };
+        };
+    };
+};
+
+class GSRI_helmet_modular_integral : GSRI_helmet_modular_advanced {
     author = "$STR_GSRI_AUTHORS_PHILEAS";
     displayName = "$STR_GSRI_HEADGEAR_HELMET_MODULAR_INTEGRAL";
     descriptionShort="$STR_A3_SP_AL_II";
     picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet_modular_accessories.paa";
     model = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_chops_F.p3d";
-    ace_hearing_protection = 0.5;
-    ace_hearing_lowerVolume = 0.3;
     class ItemInfo : HeadgearItem {
         mass = 30;
         uniformModel = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_chops_F.p3d";

--- a/addons/gsri_equipment/headgear/headgear.hpp
+++ b/addons/gsri_equipment/headgear/headgear.hpp
@@ -27,6 +27,7 @@ class GSRI_helmet : H_HelmetB {
     author = "$STR_GSRI_AUTHORS_PHILEAS";
     weaponPoolAvailable = 1;
     displayName = "$STR_GSRI_HEADGEAR_HELMET";
+    descriptionShort="$STR_A3_SP_AL_II";
     picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet.paa";
     model = "\A3\Characters_F\BLUFOR\headgear_b_helmet_plain.p3d";
     hiddenSelections[] = { "camo" };
@@ -53,6 +54,7 @@ class GSRI_helmet_spec : H_HelmetSpecB {
     author = "$STR_GSRI_AUTHORS_PHILEAS";
     weaponPoolAvailable = 1;
     displayName = "$STR_GSRI_HEADGEAR_HELMET_ACCESSORIES";
+    descriptionShort="$STR_A3_SP_AL_II";
     picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet_accessories.paa";
     model = "\A3\Characters_F\BLUFOR\headgear_b_helmet_ballistic.p3d";
     hiddenSelections[] = { "camo" };
@@ -79,6 +81,7 @@ class GSRI_helmet_light : H_HelmetB_light {
     author = "$STR_GSRI_AUTHORS_PHILEAS";
     weaponPoolAvailable = 1;
     displayName = "$STR_GSRI_HEADGEAR_HELMET_LIGHT";
+    descriptionShort="$STR_A3_SP_AL_II";
     picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet_light.paa";
     model = "\A3\Characters_F\BLUFOR\headgear_b_helmet_light.p3d";
     hiddenSelections[] = { "camo" };
@@ -105,6 +108,7 @@ class GSRI_helmet_modular : H_HelmetB {
     author = "$STR_GSRI_AUTHORS_PHILEAS";
     weaponPoolAvailable = 1;
     displayName = "$STR_GSRI_HEADGEAR_HELMET_MODULAR";
+    descriptionShort="$STR_A3_SP_AL_II";
     picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet_modular.paa";
     model = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_F.p3d";
     hiddenSelections[] = { "camo" };
@@ -129,6 +133,7 @@ class GSRI_helmet_modular : H_HelmetB {
 class GSRI_helmet_modular_advanced : GSRI_helmet_modular {
     author = "$STR_GSRI_AUTHORS_PHILEAS";
     displayName = "$STR_GSRI_HEADGEAR_HELMET_MODULAR_ACCESSORIES";
+    descriptionShort="$STR_A3_SP_AL_II";
     picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet_modular_accessories.paa";
     model = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_headset_F.p3d";
     ace_hearing_protection = 0.5;
@@ -151,6 +156,7 @@ class GSRI_helmet_modular_advanced : GSRI_helmet_modular {
 class GSRI_helmet_modular_integral : GSRI_helmet_modular {
     author = "$STR_GSRI_AUTHORS_PHILEAS";
     displayName = "$STR_GSRI_HEADGEAR_HELMET_MODULAR_INTEGRAL";
+    descriptionShort="$STR_A3_SP_AL_II";
     picture = "\fr\gsri\equipment\headgear\UI\icon_gsri_helmet_modular_accessories.paa";
     model = "\A3\Characters_F_Enoch\Headgear\H_HelmetHBK_01_chops_F.p3d";
     ace_hearing_protection = 0.5;

--- a/addons/gsri_equipment/stringtable.xml
+++ b/addons/gsri_equipment/stringtable.xml
@@ -85,6 +85,11 @@
                 <English>[-GSRI-] Modular helmet (accessories)</English>
                 <French>[-GSRI-] Casque modulaire (accessoires)</French>
             </Key>
+            <Key ID="STR_GSRI_HEADGEAR_HELMET_MODULAR_HALFINTEGRAL">
+                <Original>[-GSRI-] Modular helmet (half-integral)</Original>
+                <English>[-GSRI-] Modular helmet (half-integral)</English>
+                <French>[-GSRI-] Casque modulaire (semi-intégral)</French>
+            </Key>
             <Key ID="STR_GSRI_HEADGEAR_HELMET_MODULAR_INTEGRAL">
                 <Original>[-GSRI-] Modular helmet (integral)</Original>
                 <English>[-GSRI-] Modular helmet (integral)</English>


### PR DESCRIPTION
This will fix #33 by adding a balanced hearing protection :
- helmet with no visible protection have no effect on hearing.
- helmet with visible protection have an effect on damage (50% reduction) and perception (30% volume reduction).

Using only earplugs will prevent 75% of damages, but also cause a 50% volume reduction. Best protection is achieved by combining earplugs and protective helmets, since ACE hearing damage protection is cumulative.

In the end :
- no protection : 100% hearing capacity , 0% damage reduction.
- earplugs alone (or with unprotected helmet): 50% hearing capacity, 75% damage reduction.
- protective helmet alone : 70% hearing capacity, but only 50% damage reduction.
- earplugs + protected helmet : only 35% hearing capacity, but almost 88% damage reduction.