### PR TITLE
Fix for GL ammo not added to the player inv

### DIFF
--- a/addons/gsri_props/lockers/Functions/fn_gearAsGcap.sqf
+++ b/addons/gsri_props/lockers/Functions/fn_gearAsGcap.sqf
@@ -129,13 +129,13 @@ switch(_role) do
 	};
 	case "Grenadier": {
 		for "_i" from 1 to 10 do {
-			this addItemToBackpack "1Rnd_HE_Grenade_shell";
+			player addItemToBackpack "1Rnd_HE_Grenade_shell";
 		};
 		for "_i" from 1 to 10 do {
-			this addItemToBackpack "ACE_40mm_Flare_white";
+			player addItemToBackpack "ACE_40mm_Flare_white";
 		};
 		for "_i" from 1 to 10 do {
-			this addItemToBackpack "1Rnd_Smoke_Grenade_shell";
+			player addItemToBackpack "1Rnd_Smoke_Grenade_shell";
 		};
 	};
 	case "Lead": {


### PR DESCRIPTION
Fix for #56, GL ammo not added to the player inventory.

"this" was used instead of "player" for the addItemToBackpack